### PR TITLE
support vega-lite specs

### DIFF
--- a/examples/XVega operations.ipynb
+++ b/examples/XVega operations.ipynb
@@ -53,6 +53,91 @@
    "source": [
     "%XVEGA_PLOT X_FIELD EmployeeId GRID false Y_FIELD ReportsTo MARK area COLOR pink WIDTH 200 HEIGHT 200 <> SELECT EmployeeId, ReportsTo FROM employees"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`%VEGA-LITE` follow by a json specs, with a new line followed by a SQL commands"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%VEGA-LITE rect_category_heatmap.vl.json\n",
+    "select i.BillingCountry as Country, g.name as Genre, count(1) as c\n",
+    "from invoices i \n",
+    "    inner join invoice_items il on i.InvoiceId=il.InvoiceId \n",
+    "    inner join tracks t on t.TrackId=il.TrackId \n",
+    "    inner join genres g on g.GenreId=t.GenreId\n",
+    "group by 1,2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create a new spec on the fly by `VEGA-LITE SET spec_name` then followed by the json spec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%VEGA-LITE SET colored_scatterplot.vl.json\n",
+    "{\n",
+    "  \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.json\",\n",
+    "  \"data\": {\"url\": \"data/movies.json\"},\n",
+    "  \"mark\": \"circle\",\n",
+    "  \"width\": 400,\n",
+    "  \"height\": 300,\n",
+    "  \"encoding\": {\n",
+    "    \"x\": {\n",
+    "      \"field\": \"trackNo\", \"sort\": \"ascending\", \"type\": \"quantitative\"\n",
+    "    },\n",
+    "    \"y\": {\n",
+    "      \"field\": \"sales\", \"type\": \"quantitative\"\n",
+    "    },\n",
+    "    \"color\": {\"field\": \"name\", \"type\": \"nominal\", \"sort\": {\"field\": \"-x\", \"order\": \"descending\"}},\n",
+    "    \"size\": {\"field\": \"sales\", \"type\": \"quantitative\"}\n",
+    "  }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When plot we will first try if the spec is defined before, then check the file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%VEGA-LITE colored_scatterplot.vl.json\n",
+    "select g.name name, sum(i.total) sales, count(distinct t.trackId) trackNo \n",
+    "from tracks t \n",
+    "    inner join genres g on g.genreId=t.genreId \n",
+    "    inner join invoice_items il on il.trackId=t.trackId\n",
+    "    inner join invoices i on i.invoiceId=il.invoiceLineId\n",
+    "group by g.name\n",
+    "order by sales desc limit 10;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -66,7 +151,7 @@
    "file_extension": "",
    "mimetype": "",
    "name": "mysql",
-   "version": "0.0.4"
+   "version": "0.0.6"
   }
  },
  "nbformat": 4,

--- a/examples/XVega operations.ipynb
+++ b/examples/XVega operations.ipynb
@@ -58,7 +58,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`%VEGA-LITE` follow by a json specs, with a new line followed by a SQL commands"
+    "`%VEGA_LITE` follow by a json specs, with a new line followed by a SQL commands"
    ]
   },
   {
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%VEGA-LITE rect_category_heatmap.vl.json\n",
+    "%VEGA_LITE rect_category_heatmap.vl.json\n",
     "select i.BillingCountry as Country, g.name as Genre, count(1) as c\n",
     "from invoices i \n",
     "    inner join invoice_items il on i.InvoiceId=il.InvoiceId \n",
@@ -80,7 +80,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a new spec on the fly by `VEGA-LITE SET spec_name` then followed by the json spec"
+    "Create a new spec on the fly by `VEGA_LITE SET spec_name` then followed by the json spec"
    ]
   },
   {
@@ -89,7 +89,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%VEGA-LITE SET colored_scatterplot.vl.json\n",
+    "%VEGA_LITE SET colored_scatterplot.vl.json\n",
     "{\n",
     "  \"$schema\": \"https://vega.github.io/schema/vega-lite/v4.json\",\n",
     "  \"data\": {\"url\": \"data/movies.json\"},\n",
@@ -122,7 +122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%VEGA-LITE colored_scatterplot.vl.json\n",
+    "%VEGA_LITE colored_scatterplot.vl.json\n",
     "select g.name name, sum(i.total) sales, count(distinct t.trackId) trackNo \n",
     "from tracks t \n",
     "    inner join genres g on g.genreId=t.genreId \n",
@@ -131,13 +131,6 @@
     "group by g.name\n",
     "order by sales desc limit 10;"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/rect_category_heatmap.vl.json
+++ b/examples/rect_category_heatmap.vl.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "data": {"url": "data/movies.json"},
+  "mark": "rect",
+  "width": 600,
+  "height": 400,
+  "encoding": {
+    "x": {
+      "field": "Country",
+      "type": "nominal"
+    },
+    "y": {
+      "field": "Genre",
+      "type": "nominal"
+    },
+    "color": {
+      "type": "quantitative",
+      "field": "c"
+    }
+  },
+  "config": {
+    "view": {
+      "stroke": "transparent"
+    }
+  }
+}

--- a/include/xeus-sql/xeus_sql_interpreter.hpp
+++ b/include/xeus-sql/xeus_sql_interpreter.hpp
@@ -50,6 +50,7 @@ namespace xeus_sql
                                    xv::df_type& xv_sqlite_df);
 
         std::unique_ptr<soci::session> sql;
+        std::map<std::string, nl::json> specs;
     };
 }
 

--- a/src/xeus_sql_interpreter.cpp
+++ b/src/xeus_sql_interpreter.cpp
@@ -230,7 +230,7 @@ namespace xeus_sql
                                              nl::json::object());
 
                     return ok();
-                } else if (xv_bindings::case_insentive_equals("VEGA-LITE", tokenized_input[0])) {
+                } else if (xv_bindings::case_insentive_equals("VEGA_LITE", tokenized_input[0])) {
                     if (tokenized_input.size() < 2) {
                         throw std::runtime_error("invalid input: " + code);
                     }


### PR DESCRIPTION
I think after support json spec, we can delete the %XVEGA_PLOT command, and we don't need the parsers. Maybe we can decouple from xv_bindings, as what left is some helper functions in there.

Close #17 