### PR TITLE
Update cpp-tabulate dependency to v1.5

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ The xeus team organizes public video meetings. The schedule for future meetings 
 To install the xeus-sql dependencies:
 
 ```bash
-mamba install nlohmann_json xtl cppzmq xeus cpp-tabulate=1.3 xvega xvega-bindings xproperty jupyterlab soci-core compilers cmake -c conda-forge
+mamba install nlohmann_json xtl cppzmq xeus cpp-tabulate>=1.5 xvega xvega-bindings xproperty jupyterlab soci-core compilers cmake -c conda-forge
 ```
 
 #### Known issues

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -61,11 +61,11 @@ You can install ``xeus-sql`` from source with ``cmake``. This requires that you 
 
 .. code::
 
-    conda install cmake nlohmann_json xtl cppzmq xeus mysql sqlite postgresql cpp-tabulate=1.3 xvega xvega-bindings xproperty jupyterlab compilers -c conda-forge
+    conda install cmake nlohmann_json xtl cppzmq xeus mysql sqlite postgresql cpp-tabulate>=1.5 xvega xvega-bindings xproperty jupyterlab compilers -c conda-forge
 
 .. code::
 
-    mamba install cmake nlohmann_json xtl cppzmq xeus mysql sqlite postgresql cpp-tabulate=1.3 xvega xvega-bindings xproperty jupyterlab compilers -c conda-forge
+    mamba install cmake nlohmann_json xtl cppzmq xeus mysql sqlite postgresql cpp-tabulate>=1.5 xvega xvega-bindings xproperty jupyterlab compilers -c conda-forge
 
 .. code::
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - cxx-compiler
   - ninja
   # host dependencies
-  - cpp-tabulate=1.3
+  - cpp-tabulate>=1.5
   - cppzmq
   - nlohmann_json
   - soci-core

--- a/src/xeus_sql_interpreter.cpp
+++ b/src/xeus_sql_interpreter.cpp
@@ -94,7 +94,7 @@ namespace xeus_sql
         for (const soci::row& r : rows)
         {
             if (row_count == 0) {
-                std::vector<variant<std::string, const char*, tabulate::Table>> col_names;
+                tabulate::Table::Row_t col_names;
                 html_table << "<table>\n<tr>\n";
                 for (std::size_t i = 0; i != r.size(); ++i) {
                     std::string name = r.get_properties(i).get_name();
@@ -108,7 +108,7 @@ namespace xeus_sql
             /* Iterates through cols' rows and builds different kinds of
                outputs
             */
-            std::vector<variant<std::string, const char*, tabulate::Table>> row;
+            tabulate::Table::Row_t row;
             html_table << "<tr>\n";
             for(std::size_t i = 0; i != r.size(); ++i)
             {


### PR DESCRIPTION
Support was added for `std::string_view` (https://github.com/p-ranav/tabulate/pull/77) which changed the row type.

Previously:
```cpp
std::vector<variant<std::string, const char*, tabulate::Table>> row;
```

With v1.5:
```cpp
std::vector<variant<std::string, const char *, std::string_view, tabulate::Table>>
```
